### PR TITLE
Add a makefile for testing downstream CI

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -1,0 +1,17 @@
+NIGHTLY_YAML=https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-next/openshift/release/tektoncd-pipeline-nightly.yaml
+STABLE_VERSION=$(shell curl -s https://api.github.com/repos/tektoncd/pipeline/releases | python -c "import sys, json;x=json.load(sys.stdin);print(x[0]['tag_name'])")
+RELEASE_YAML=
+
+test-e2e-downstream-nightly:
+	@make test-e2e-downstream RELEASE_YAML=$(NIGHTLY_YAML)
+.PHONY: test-e2e-downstream-nightly
+
+test-e2e-downstream-stable:
+	@make test-e2e-downstream \
+		RELEASE_YAML=https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-$(STABLE_VERSION)/openshift/release/tektoncd-pipeline-$(STABLE_VERSION).yaml
+.PHONY: test-e2e-downstream-stable
+
+test-e2e-downstream:
+	@make -C ../ bin/tkn
+	@env RELEASE_YAML=$(RELEASE_YAML) LOCAL_CI_RUN=true ../test/e2e-tests.sh
+.PHONY: test-e2e-downstream


### PR DESCRIPTION
You have two targets :

test-e2e-downstream-nightly:
    Runs against the nightly version

test-e2e-downstream-stable:
    Would by default run against the latest stable version as detected on
    upstream releases, you can override this with STABLE_VERSION as :

    make test-e2e-downstream-stable STABLE_VERSION=v0.7.0

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
