### PR TITLE
Sets GO111MODULE=on to use -mod=vendor flag

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -2,6 +2,9 @@ NIGHTLY_YAML=https://raw.githubusercontent.com/openshift/tektoncd-pipeline/relea
 STABLE_PIPELINE_VERSION=$(shell curl -s https://api.github.com/repos/tektoncd/pipeline/releases | python -c "import sys, json;x=json.load(sys.stdin);print(x[0]['tag_name'])")
 STABLE_RELEASE_YAML=https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-$(STABLE_PIPELINE_VERSION)/openshift/release/tektoncd-pipeline-$(STABLE_PIPELINE_VERSION).yaml
 RELEASE_YAML=
+# Turn the modules on as we're using `-mod=vendor` flag while building the binaries
+# and the source code is cloned under $GOPATH
+export GO111MODULE=on
 
 # Temporary hack to use the stable release if nightly doesn't exist, in case release fails
 test-e2e-downstream-nightly:


### PR DESCRIPTION
 - as we're cloning the source code in $GOPATH

/hold