### PR TITLE
Better detection of stable version

### DIFF
--- a/openshift/Makefile
+++ b/openshift/Makefile
@@ -1,6 +1,5 @@
-NIGHTLY_YAML=https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-next/openshift/release/tektoncd-pipeline-nightly.yaml
-STABLE_PIPELINE_VERSION=$(shell curl -s https://api.github.com/repos/tektoncd/pipeline/releases | python -c "import sys, json;x=json.load(sys.stdin);print(x[0]['tag_name'])")
-STABLE_RELEASE_YAML=https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-$(STABLE_PIPELINE_VERSION)/openshift/release/tektoncd-pipeline-$(STABLE_PIPELINE_VERSION).yaml
+DETECT_RELEASE_YAML=$(shell bash pipeline-latest-release.sh)
+STABLE_RELEASE_YAML=$(shell bash pipeline-latest-release.sh --only-stable-release)
 RELEASE_YAML=
 # Turn the modules on as we're using `-mod=vendor` flag while building the binaries
 # and the source code is cloned under $GOPATH
@@ -8,9 +7,7 @@ export GO111MODULE=on
 
 # Temporary hack to use the stable release if nightly doesn't exist, in case release fails
 test-e2e-downstream-nightly:
-	@yaml=$(NIGHTLY_YAML) ;\
-	curl -s -o /dev/null -f $(NIGHTLY_YAML) || yaml=$(STABLE_RELEASE_YAML) ;\
-	make test-e2e-downstream RELEASE_YAML=$$yaml
+	make test-e2e-downstream RELEASE_YAML=$(DETECT_RELEASE_YAML)
 .PHONY: test-e2e-downstream-nightly
 
 test-e2e-downstream-stable:

--- a/openshift/pipeline-latest-release.sh
+++ b/openshift/pipeline-latest-release.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Detect which version of pipeline should be installed
+# First it tries nightly
+# If that doesn't work it tries previous releases (until the MAX_SHIFT variable)
+# If not it exit 1
+# It can take the argument --only-stable-release to not do nightly but only detect the pipeline version
+
+MAX_SHIFT=1
+NIGHTLY_RELEASE="https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-next/openshift/release/tektoncd-pipeline-nightly.yaml"
+STABLE_RELEASE_URL='https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-${version}/openshift/release/tektoncd-pipeline-${version}.yaml'
+
+function get_version {
+    local shift=${1} # 0 is latest, increase is the version before etc...
+    local version=$(curl -s https://api.github.com/repos/tektoncd/pipeline/releases | python -c "import sys, json;x=json.load(sys.stdin);print(x[${shift}]['tag_name'])")
+    echo $(eval echo ${STABLE_RELEASE_URL})
+}
+
+function tryurl {
+    curl -s -o /dev/null -f ${1} || return 1
+}
+
+if [[ ${1} != "--only-stable-release" ]];then
+   if tryurl ${NIGHTLY_RELEASE};then
+       echo ${NIGHTLY_RELEASE}
+       exit
+   fi
+fi
+
+for shifted in `seq 0 ${MAX_SHIFT}`;do
+    versionyaml=$(get_version ${shifted})
+    if tryurl ${versionyaml};then
+        echo ${versionyaml}
+        exit 0
+    fi
+done
+
+exit 1


### PR DESCRIPTION
Add a script to detect better the stable version, in case we havent released
downstream if there is a new upstream.

Jira: https://jira.coreos.com/browse/SRVKP-420
TetPR: #95 

/hold