### PR TITLE
fix create-release-branch

### DIFF
--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -17,9 +17,7 @@ git checkout -b "$target" "$release"
 
 # Update openshift's master and take all needed files from there.
 git fetch openshift master
-git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS Makefile
-make generate-dockerfiles
-make RELEASE=$release generate-release
-make RELEASE=ci generate-release
+git checkout openshift/master -- openshift OWNERS_ALIASES OWNERS
 git add openshift OWNERS_ALIASES OWNERS Makefile
 git commit -m "Add openshift specific files."
+git push openshift "$target"


### PR DESCRIPTION
the create-release-branch.sh try to checkout Makefile which is not
present.
also removes Unavailable Makefile phony
adds a git  push to openshift

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/cli/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
